### PR TITLE
chore: prepare for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 0.1.0
+
+Initial release of the range_request package for efficient HTTP file downloads with range request support.
+
+### Features
+
+- **Parallel chunked downloads** - Split large files into chunks for concurrent downloading
+- **Automatic resume capability** - Continue interrupted downloads from where they left off
+- **Checksum verification** - Verify file integrity with MD5/SHA256 algorithms
+- **Smart server fallback** - Automatically falls back to serial download if server doesn't support range requests
+- **Real-time progress tracking** - Monitor download progress with customizable update intervals
+- **Graceful cancellation** - Cancel downloads cleanly using CancelToken
+- **File conflict strategies** - Handle existing files with overwrite, rename, or error options
+- **Temporary file cleanup** - Utility for removing incomplete download files
+- **Isolate-based file I/O** - Non-blocking file operations prevent UI freezing
+- **Exponential backoff retry** - Smart retry logic for failed chunks with increasing delays
+- **Memory-efficient streaming** - Process large files without loading entire content into memory
+- **Configurable parameters** - Fine-tune chunk size, concurrency, timeouts, and retry behavior
+
+### Infrastructure
+
+- Cross-platform support for iOS, Android, Web, Windows, macOS, and Linux
+- Minimal dependencies: `http: ^1.1.0` and `crypto: ^3.0.0`
+- Dart SDK requirement: ^3.8.0
+- Example Flutter app demonstrating package capabilities

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: range_request
 description: A Dart package for efficient HTTP range requests supporting parallel chunked downloads, resume capability, and checksum verification.
-version: 0.0.1
+version: 0.1.0
 homepage: https://github.com/KyoheiG3/range_request
 repository: https://github.com/KyoheiG3/range_request
 documentation: https://github.com/KyoheiG3/range_request


### PR DESCRIPTION
## Overview
Preparing the package for its initial v0.1.0 release on pub.dev.

## Changes
- Added `CHANGELOG.md` with comprehensive release notes for v0.1.0
  - Documented all major features including parallel downloads, resume capability, and checksum verification
  - Listed infrastructure requirements and platform support
- Updated package version from `0.0.1` to `0.1.0` in `pubspec.yaml`

## Test Instructions
1. Review the CHANGELOG.md for completeness and accuracy
2. Verify version bump in pubspec.yaml
3. Run `dart pub publish --dry-run` to validate package readiness
4. Ensure all tests pass with `dart test`

## References
- [pub.dev publishing documentation](https://dart.dev/tools/pub/publishing)