### PR TITLE
feat: add CancelTokenGroup and configuration improvements

### DIFF
--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -12,7 +12,7 @@ import 'range_request_client.dart';
 class FileDownloader {
   final RangeRequestClient client;
 
-  const FileDownloader(this.client);
+  const FileDownloader([this.client = const RangeRequestClient()]);
 
   /// Create a FileDownloader with a new RangeRequestClient using the provided config
   factory FileDownloader.fromConfig(RangeRequestConfig config) {

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -69,7 +69,6 @@ class FileDownloader {
     bool resume = true,
     ChecksumType checksumType = ChecksumType.none,
     FileConflictStrategy conflictStrategy = FileConflictStrategy.overwrite,
-    Duration progressInterval = const Duration(milliseconds: 500),
     CancelToken? cancelToken,
     void Function(int bytes, int total, DownloadStatus status)? onProgress,
   }) async {
@@ -126,7 +125,6 @@ class FileDownloader {
         url: url,
         info: info,
         startBytes: startBytes,
-        progressInterval: progressInterval,
         cancelToken: cancelToken,
         onProgress: onProgress,
       );
@@ -183,7 +181,6 @@ class FileDownloader {
     required Uri url,
     required ServerInfo info,
     required int startBytes,
-    required Duration progressInterval,
     CancelToken? cancelToken,
     void Function(int, int, DownloadStatus)? onProgress,
   }) async {
@@ -195,7 +192,6 @@ class FileDownloader {
       contentLength: info.contentLength,
       acceptRanges: info.acceptRanges,
       startBytes: startBytes,
-      progressInterval: progressInterval,
       cancelToken: cancelToken,
       onProgress: (bytes, total) =>
           onProgress?.call(bytes, total, DownloadStatus.downloading),

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -88,4 +88,27 @@ class RangeRequestConfig {
     this.connectionTimeout = const Duration(seconds: 30),
     this.progressInterval = const Duration(milliseconds: 500),
   });
+
+  /// Creates a copy of this configuration with the given fields replaced with new values
+  RangeRequestConfig copyWith({
+    int? chunkSize,
+    int? maxConcurrentRequests,
+    Map<String, String>? headers,
+    int? maxRetries,
+    int? retryDelayMs,
+    String? tempFileExtension,
+    Duration? connectionTimeout,
+    Duration? progressInterval,
+  }) {
+    return RangeRequestConfig(
+      chunkSize: chunkSize ?? this.chunkSize,
+      maxConcurrentRequests: maxConcurrentRequests ?? this.maxConcurrentRequests,
+      headers: headers ?? this.headers,
+      maxRetries: maxRetries ?? this.maxRetries,
+      retryDelayMs: retryDelayMs ?? this.retryDelayMs,
+      tempFileExtension: tempFileExtension ?? this.tempFileExtension,
+      connectionTimeout: connectionTimeout ?? this.connectionTimeout,
+      progressInterval: progressInterval ?? this.progressInterval,
+    );
+  }
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -75,6 +75,9 @@ class RangeRequestConfig {
   /// Connection timeout for HTTP requests (default: 30 seconds)
   final Duration connectionTimeout;
 
+  /// Interval for progress callbacks (default: 500 milliseconds)
+  final Duration progressInterval;
+
   const RangeRequestConfig({
     this.chunkSize = 10 * 1024 * 1024, // 10MB
     this.maxConcurrentRequests = 8,
@@ -83,5 +86,6 @@ class RangeRequestConfig {
     this.retryDelayMs = 1000,
     this.tempFileExtension = '.tmp',
     this.connectionTimeout = const Duration(seconds: 30),
+    this.progressInterval = const Duration(milliseconds: 500),
   });
 }

--- a/lib/src/range_request_client.dart
+++ b/lib/src/range_request_client.dart
@@ -153,7 +153,6 @@ class RangeRequestClient {
     int? contentLength,
     bool? acceptRanges,
     int startBytes = 0,
-    Duration progressInterval = const Duration(milliseconds: 500),
     CancelToken? cancelToken,
     void Function(int bytes, int total)? onProgress,
   }) async* {
@@ -173,7 +172,7 @@ class RangeRequestClient {
     // Set up progress timer if callback provided
     Timer? progressTimer;
     if (onProgress != null) {
-      progressTimer = Timer.periodic(progressInterval, (_) {
+      progressTimer = Timer.periodic(config.progressInterval, (_) {
         if (receivedBytes > 0) {
           onProgress(receivedBytes, info.contentLength);
         }

--- a/test/file_downloader_test.dart
+++ b/test/file_downloader_test.dart
@@ -243,13 +243,15 @@ void main() {
 
           // When: Downloading with progress callback
           final downloader = FileDownloader.fromConfig(
-            RangeRequestConfig(chunkSize: 10),
+            RangeRequestConfig(
+              chunkSize: 10,
+              progressInterval: const Duration(milliseconds: 10),
+            ),
           );
           await downloader.downloadToFile(
             serverUrl,
             tempDir.path,
             checksumType: ChecksumType.sha256,
-            progressInterval: const Duration(milliseconds: 10),
             onProgress: (bytes, total, status) {
               progressReports.add((bytes, total, status));
             },

--- a/test/range_request_client_test.dart
+++ b/test/range_request_client_test.dart
@@ -426,12 +426,15 @@ void main() {
           });
 
           // When: Fetching with progress callback
-          final client = RangeRequestClient();
+          final client = RangeRequestClient(
+            config: RangeRequestConfig(
+              progressInterval: const Duration(milliseconds: 20),
+            ),
+          );
           final progressReports = <(int, int)>[];
 
           await for (final _ in client.fetch(
             serverUrl,
-            progressInterval: const Duration(milliseconds: 20),
             onProgress: (bytes, total) {
               progressReports.add((bytes, total));
             },


### PR DESCRIPTION
## Overview
Added `CancelTokenGroup` for managing multiple cancel tokens, improved configuration with `copyWith` method, and refactored progress interval handling.

## Changes
### New Features
- **CancelTokenGroup**: Added new class to manage and cancel multiple operations at once
  - Create and track multiple cancel tokens
  - Cancel all tokens simultaneously
  - Check group status (any/all cancelled)
  - Add/remove tokens dynamically

### Configuration Improvements
- **RangeRequestConfig.copyWith**: Added `copyWith` method for easy configuration updates
- **Progress Interval**: Moved `progressInterval` from method parameter to configuration
  - Now part of `RangeRequestConfig` for consistent behavior
  - Default value: 500ms

### API Improvements
- **FileDownloader**: Added default parameter for constructor
  - Can now instantiate without arguments: `FileDownloader()`
  - Uses default `RangeRequestClient()` instance

## Test Plan
- [x] All existing tests pass (129 tests)
- [x] Added comprehensive tests for `CancelTokenGroup`
- [x] Added tests for `copyWith` method
- [x] Updated tests for progress interval changes
- [x] Static analysis shows no issues

## Breaking Changes
- `progressInterval` parameter removed from:
  - `RangeRequestClient.fetch()`
  - `FileDownloader.downloadToFile()`
  
Migration: Pass `progressInterval` via `RangeRequestConfig` instead:
```dart
// Before
client.fetch(url, progressInterval: Duration(seconds: 1))

// After
final client = RangeRequestClient(
  config: RangeRequestConfig(progressInterval: Duration(seconds: 1))
);
client.fetch(url)
```